### PR TITLE
chore: 调整holdPlayerWhilePlayEnd API为deallocPlayerWhilePlayEnd，默认播放完后不释放

### DIFF
--- a/ZFPlayer/ZFPlayerView.h
+++ b/ZFPlayer/ZFPlayerView.h
@@ -88,8 +88,8 @@ typedef NS_ENUM(NSInteger, ZFPlayerState) {
 @property (nonatomic, assign) BOOL                    fullScreenPlay;
 /// 占位图
 @property (nonatomic, strong) UIImageView *placeholderBlurImageView;
-/// 播放结束后是否继续持有播发器
-@property (nonatomic, assign) BOOL                    holdPlayerWhilePlayEnd;
+/// 播放结束后是否释放 默认NO
+@property (nonatomic, assign) BOOL                    deallocPlayerWhilePlayEnd;
 
 /**
  *  单例，用于列表cell上多个视频

--- a/ZFPlayer/ZFPlayerView.m
+++ b/ZFPlayer/ZFPlayerView.m
@@ -1141,7 +1141,7 @@ typedef NS_ENUM(NSInteger, PanDirection){
         if (!self.isDragged) { // 如果不是拖拽中，直接结束播放
             self.playDidEnd = YES;
             [self.controlView zf_playerPlayEnd];
-            if (!self.holdPlayerWhilePlayEnd) {
+            if (self.deallocPlayerWhilePlayEnd) {
                 [self.playerLayer removeFromSuperlayer];
                 [self.placeholderBlurImageView removeFromSuperview];
                 self.imageGenerator = nil;


### PR DESCRIPTION
调整回原来的业务逻辑，否则对其他项目有影响